### PR TITLE
Patch to display direwolf AIS packets that have as "from" field all AIS.

### DIFF
--- a/static/map.html
+++ b/static/map.html
@@ -1010,6 +1010,12 @@ function rebuildPopup(station) {
                class="aprsfi-link" 
                target="_blank">
               aprs.fi
+            </a>
+            |
+            <a href="https://www.vesselfinder.com/vessels/details/${encodeURIComponent(station.replace(/^AIS-/, ''))}"
+               class="aprsfi-link"
+               target="_blank">
+              VesselFinder
             </a>`;
 
     // Append the extra "LoRa" link if the 'To' field matches either value.

--- a/tnc.py
+++ b/tnc.py
@@ -483,11 +483,20 @@ def parse_ax25_frame(frame):
 
 def decode_aprs(full_packet):
     try:
-        return aprslib.parse(full_packet)
+        parsed = aprslib.parse(full_packet)
     except Exception as e:
         if config.get('debug'):
             print(f"APRS decode error: {e}")
         return None
+
+    # --- patch: rewrite source if is AIS packet ---
+    if parsed.get('from') == 'AIS' and parsed.get('object_name'):
+        mmsi = str(parsed['object_name']).strip()
+        parsed['orig_from'] = parsed['from']
+        parsed['from'] = f"AIS-{mmsi}"
+    # ---------------------------------------------------------
+
+    return parsed
 
 # ------------------------------------------------------------------------------
 #                           UDP Forwarding (iGate) + MQTT-FORWARD


### PR DESCRIPTION
Direwolf now supports AIS messages and can translate them into APRS mesages on port 8001. In this way aprs-tnc-web-bridge is almost perfect to display also boats. The only problem is that direwolf uses AIS as source for all the messages, so aprs-tnc-web-bridge doesn't understand that the messages come from different transmitters, instead it moves from one boat to the next as if it is only one object.

To fix this I simply modified the aprs parser and if the message has as "from" only the label AIS I add to it the MMSI number that is in the packet as "object_name", in this way the sender becomes AIS-XXXXXXXXX and every boat becomes unique and can be tracked as in the screenshot.

<img width="948" alt="image" src="https://github.com/user-attachments/assets/2c905677-fa4e-4d9f-864b-7db703bf3bb1" />